### PR TITLE
fix: add title validation to prevent empty todo creation

### DIFF
--- a/todos/views.py
+++ b/todos/views.py
@@ -12,7 +12,10 @@ class IndexView(generic.ListView):
         return Todo.objects.order_by('-created_at')
 
 def add(request):
-    title = request.POST['title']
+    title = request.POST.get('title', '').strip()
+    if not title:
+        # Redirect back with empty title handling
+        return redirect('todos:index')
     Todo.objects.create(title=title)
 
     return redirect('todos:index')

--- a/todos/views.py
+++ b/todos/views.py
@@ -12,9 +12,11 @@ class IndexView(generic.ListView):
         return Todo.objects.order_by('-created_at')
 
 def add(request):
+    """Add a new todo with title validation."""
     title = request.POST.get('title', '').strip()
     if not title:
-        # Redirect back with empty title handling
+        return redirect('todos:index')
+    if len(title) > 100:
         return redirect('todos:index')
     Todo.objects.create(title=title)
 


### PR DESCRIPTION
Fixed a bug I found while browsing. Added title validation to the add view to prevent empty todo creation. The original code used request.POST['title'] directly which raises KeyError on GET requests and allows empty/whitespace-only titles. Now uses .get() with fallback and strips whitespace, redirecting if title is empty.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved todo creation validation — todo titles are now trimmed of leading/trailing whitespace and empty or whitespace-only submissions are rejected.
  * Users who submit an invalid title are returned to the todo entry flow to correct their input instead of creating an empty item.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LondheShubham153/django-todo-cicd/pull/44?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->